### PR TITLE
Add TypeScript tooling for Week5 exercises

### DIFF
--- a/Week5/.gitignore
+++ b/Week5/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/Week5/README.md
+++ b/Week5/README.md
@@ -1,0 +1,11 @@
+# Week 5 TypeScript Setup
+
+## Instalación
+
+1. Abre una terminal en este directorio (`Week5/`).
+2. Ejecuta `npm install` para instalar las dependencias de desarrollo.
+
+## Compilación
+
+- Ejecuta `npm run build` para compilar `day1.ts` y generar los archivos en `dist/`.
+- Opcionalmente, después de compilar puedes correr `npm start` para ejecutar la versión compilada con Node.js.

--- a/Week5/day1.ts
+++ b/Week5/day1.ts
@@ -1,29 +1,33 @@
 // Day 1 TypeScript examples
 
 // Simple typed function
-function greet(name: string): string {
-	return `Hello, ${name}!`;
+export function greet(name: string): string {
+        return `Hello, ${name}!`;
 }
 
-console.log(greet("World"));
-
-// Loop example
-for (let i = 0; i < 5; i++) {
-	console.log(`Index: ${i}`);
+export interface Student {
+        id: number;
+        name: string;
+        active: boolean;
 }
 
-// Interface and object example
-interface Student {
-	id: number;
-	name: string;
-	active: boolean;
-}
-
-const students: Student[] = [
-	{ id: 1, name: "Alice", active: true },
-	{ id: 2, name: "Bob", active: false },
+export const students: Student[] = [
+        { id: 1, name: "Alice", active: true },
+        { id: 2, name: "Bob", active: false },
 ];
 
-students
-	.filter(s => s.active)
-	.forEach(s => console.log(`Active student: ${s.name}`));
+export function getActiveStudents(list: Student[]): Student[] {
+        return list.filter(student => student.active);
+}
+
+if (require.main === module) {
+        console.log(greet("World"));
+
+        for (let i = 0; i < 5; i++) {
+                console.log(`Index: ${i}`);
+        }
+
+        getActiveStudents(students).forEach(student =>
+                console.log(`Active student: ${student.name}`)
+        );
+}

--- a/Week5/package-lock.json
+++ b/Week5/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "week5",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "week5",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/Week5/package.json
+++ b/Week5/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "week5",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/day1.js"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.5"
+  }
+}

--- a/Week5/tsconfig.json
+++ b/Week5/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "rootDir": "./",
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["day1.ts"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add a Node-based TypeScript toolchain with build and start scripts
- expose reusable functions from `day1.ts` for easier testing
- document installation and compilation steps in a new README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68deb251766c832bb8c610d1e770c77e