### PR TITLE
Add root .gitignore and document ignoring build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+env/
+venv/
+ENV/
+.venv/
+.ipynb_checkpoints/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+.eggs/
+instance/
+
+# Node/TypeScript artifacts
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+.next/
+.nuxt/
+.svelte-kit/
+coverage/
+web-dist/
+
+# Build outputs
+/dist/
+/out/
+/tmp/
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+*.swp
+.idea/
+.vscode/
+*.iml
+*.local
+*.cache/
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Misc
+.DS_Store
+*.bak
+*.orig
+*.rej

--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ node dist/week5/day1.js # Run specific compiled file
 - **🔧 Modularity**: Single responsibility principle, reusable functions
 - **🔷 Type Safety**: TypeScript interfaces, Python type hints (future)
 
+### 🚫 Version Control Hygiene
+- **🧼 Clean Commits**: Keep version history focused on source code and learning materials.
+- **📦 Ignore Build Artifacts**: Exclude compiled assets (e.g., `__pycache__/`, `dist/`, `node_modules/`) and local environment files via the project `.gitignore`.
+- **🔁 Regenerate Locally**: Rebuild assets as needed instead of committing generated outputs.
+
 ---
 ## 8. 📊 Assessment & Progress Tracking
 


### PR DESCRIPTION
## Summary
- add a project-wide .gitignore covering Python, Node/TypeScript, and environment artifacts
- note in the documentation that generated build outputs should remain outside version control

## Testing
- not run (documentation and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68debbaaaef0832bbe1dcad725364d6e