### PR TITLE
Fix Day 2 README filenames for Gold and Ninja exercises

### DIFF
--- a/Week1Python/Day2ListsIteratingandFormattingData/DailyChallenge/GoldHappyBirthday/README.md
+++ b/Week1Python/Day2ListsIteratingandFormattingData/DailyChallenge/GoldHappyBirthday/README.md
@@ -1,6 +1,6 @@
 # Daily Challenge GOLD — Happy Birthday
 
-A tiny Python script that asks for your **birthdate**, prints your **age**, and draws a cute ASCII **birthday cake** with candles equal to the **last digit** of your age. If you were **born in a leap year**, it prints **two cakes** (bonus!).
+A tiny Python script that asks for your **birthdate**, computes your **age** to size the candles, and draws a cute ASCII **birthday cake** with candles equal to the **last digit** of your age. If you were **born in a leap year**, it prints **two cakes** (bonus!).
 
 ## 🎯 What it does (step by step)
 1. **Asks for your birthdate** in the format `DD/MM/YYYY` (example: `16/06/1994`).
@@ -28,17 +28,17 @@ If `candles = 3`, the top looks like:
 
 ## ▶️ How to run
 ### Option A — Double click (if `.py` is associated to Python on your OS)
-- Save the file as `happy_birthday.py` and double click.
+- Save the file as `happybirthday.py` and double click.
 
 ### Option B — Terminal / Command Prompt
 ```bash
 # macOS / Linux
-python3 happy_birthday.py
+python3 happybirthday.py
 
 # Windows
-python happy_birthday.py
+python happybirthday.py
 # or
-py happy_birthday.py
+py happybirthday.py
 ```
 When prompted, type your birthdate as `DD/MM/YYYY` and press Enter.
 

--- a/Week1Python/Day2ListsIteratingandFormattingData/Exercises/ExercisesXPGold/README.md
+++ b/Week1Python/Day2ListsIteratingandFormattingData/Exercises/ExercisesXPGold/README.md
@@ -46,17 +46,17 @@ A compact set of nine small exercises.
 ## ▶️ How to run
 
 ### Option A — Double click (if `.py` is associated to Python on your OS)
-- Save as `exercises_xp_gold.py` and double click.
+- Save as `exercisesxpgold.py` and double click.
 
 ### Option B — Terminal / Command Prompt
 ```bash
 # macOS / Linux
-python3 exercises_xp_gold.py
+python3 exercisesxpgold.py
 
 # Windows
-python exercises_xp_gold.py
+python exercisesxpgold.py
 # or
-py exercises_xp_gold.py
+py exercisesxpgold.py
 ```
 
 You’ll be prompted for input in several exercises (3–4, 6, 8–9).

--- a/Week1Python/Day2ListsIteratingandFormattingData/Exercises/ExercisesXPNinja/README.md
+++ b/Week1Python/Day2ListsIteratingandFormattingData/Exercises/ExercisesXPNinja/README.md
@@ -11,14 +11,14 @@ A tiny collection of Python practice exercises I wrote to train basics like inpu
 ## 🚀 How to run
 
 ```bash
-python3 main.py
+python3 exercisesxpninja.py
 ```
 
 - The script prints the results for each exercise in order.
 - It **asks for input** in Exercise 1 (comma‑separated numbers) and in Exercise 4 (a line of text).
 - Everything else runs automatically and prints to the console.
 
-If your file has a different name, just replace `main.py` with your filename.
+If your file has a different name, just replace `exercisesxpninja.py` with your filename.
 
 ---
 


### PR DESCRIPTION
## Summary
- update the Day 2 Gold README run instructions to use exercisesxpgold.py
- point the Day 2 Ninja README to exercisesxpninja.py and adjust the rename note
- align the Gold Happy Birthday README description and run commands with happybirthday.py

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df5da995c0832bb7999a3c5ff3b87b