### PR TITLE
Update Day3 run instructions to match script names

### DIFF
--- a/Week1Python/Day3Dictionaries/DailyChallenge/Dictionaries/README.md
+++ b/Week1Python/Day3Dictionaries/DailyChallenge/Dictionaries/README.md
@@ -9,9 +9,9 @@ Two small problems written in a clean, readable way with tiny comments.
 ## How to run
 
 ```bash
-python3 main.py
+python3 dictionaries.py
 ```
-Replace `main.py` with your filename if it’s different.
+Run the provided `dictionaries.py` script.
 
 ---
 

--- a/Week1Python/Day3Dictionaries/Exercises/ExercisesXP+/README.md
+++ b/Week1Python/Day3Dictionaries/Exercises/ExercisesXP+/README.md
@@ -9,9 +9,9 @@ Two small exercises: one for computing grade summaries and letter grades, and on
 ## 🚀 How to run
 
 ```bash
-python3 main.py
+python3 exercisesxpplus.py
 ```
-Replace `main.py` with your filename if different.
+Run the bundled script `exercisesxpplus.py`.
 
 ---
 

--- a/Week1Python/Day3Dictionaries/Exercises/ExercisesXP/README.md
+++ b/Week1Python/Day3Dictionaries/Exercises/ExercisesXP/README.md
@@ -9,9 +9,9 @@ Compact notes for four small dictionary exercises. Clear steps and tiny code sni
 ## 🚀 How to run
 
 ```bash
-python3 main.py
+python3 exercisesxp.py
 ```
-Replace `main.py` with your filename if different.  
+The script lives in `exercisesxp.py`.
 Parts of the script read input (bonus in Exercise 2), the rest just print.
 
 ---

--- a/Week1Python/Day3Dictionaries/Exercises/ExercisesXPGold/README.md
+++ b/Week1Python/Day3Dictionaries/Exercises/ExercisesXPGold/README.md
@@ -9,9 +9,9 @@ Two tiny console exercises: a birthday lookup (with optional insert) and a fruit
 ## 🚀 How to run
 
 ```bash
-python3 main.py
+python3 exercisesxpgold.py
 ```
-Replace `main.py` with your filename if different.
+Execute the exercises via `exercisesxpgold.py`.
 
 This script **📝 asks for input** a few times in the Birthdays section (adding a contact and doing a lookup). The Fruit Shop section just prints results.
 


### PR DESCRIPTION
## Summary
- update Day 3 dictionaries exercise READMEs to reference their actual Python entry points
- remove outdated guidance that referenced main.py scripts

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68df5db5a8e8832bbdc2eac1a22df665