### PR TITLE
Align Day 5 mini-project documentation with anagram checker

### DIFF
--- a/Week2OOP/Day5MiniProject/DailyChallenge/README.md
+++ b/Week2OOP/Day5MiniProject/DailyChallenge/README.md
@@ -1,81 +1,53 @@
-# 🏆 Daily Challenge - Sistema Integral de Biblioteca Digital
+# 🏆 Daily Challenge – Build the Anagram Checker
 
-## 🎯 Desafío Final de la Semana
+The Day 5 daily challenge is identical to the mini-project: create a playful yet well-structured **Anagram Checker**. This README now mirrors the canonical instructions in [`README_ANAGRAMS.md`](README_ANAGRAMS.md) so you always land on the correct guidance.
 
-Desarrolla un sistema completo de gestión de biblioteca digital que integre:
-- OOP avanzada
-- Organización modular
-- Manejo de archivos (CSV, JSON)
-- Consumo de APIs externas
-- Validación, testing y documentación
+> ✨ Looking for the story-style walkthrough? Jump directly to [`README_ANAGRAMS.md`](README_ANAGRAMS.md). Everything below is a concise summary.
 
 ---
 
-## 🏗️ Requisitos del Desafío
+## 🎯 Challenge Goals
 
-- Implementar clases para usuarios, libros y préstamos
-- Cargar libros desde CSV y/o API externa
-- Registrar usuarios y préstamos en JSON
-- Validar datos y manejar errores
-- Generar reportes de uso y estadísticas
-- Crear pruebas unitarias para los módulos principales
-- Documentar el sistema y justificar decisiones de diseño
+1. Implement the `AnagramChecker` class that:
+   - Loads words from `words.txt` into fast lookup structures.
+   - Validates whether a string is a real word.
+   - Finds all anagrams for a given word, excluding the word itself.
+2. Provide a lightweight CLI inside [`anagram_checker_all.py`](anagram_checker_all.py) that:
+   - Presents a simple menu (enter a word / exit).
+   - Ensures the user input is a single alphabetical word.
+   - Displays validation results and any discovered anagrams.
 
----
-
-## 📋 Sugerencia de Flujo de Trabajo
-
-1. **Modelado OOP**: Define las clases y relaciones principales
-2. **Carga de Datos**: Implementa importación desde CSV y API
-3. **Gestión de Préstamos**: Métodos para préstamo y devolución
-4. **Persistencia**: Guarda y carga datos en JSON
-5. **Reportes**: Genera reportes útiles y claros
-6. **Testing**: Pruebas unitarias para los módulos clave
-7. **Documentación**: Explica el diseño y uso del sistema
+All required logic and the menu already live together in `anagram_checker_all.py`, making it easy to review and extend.
 
 ---
 
-## 📝 Estructura de Archivos Sugerida
-```
-DailyChallenge/
-├── data/
-│   ├── books.csv
-│   ├── users.json
-│   └── loans.json
-├── src/
-│   ├── models/
-│   │   ├── user.py
-│   │   ├── book.py
-│   │   └── loan.py
-│   ├── services/
-│   │   ├── user_service.py
-│   │   ├── book_service.py
-│   │   └── loan_service.py
-│   ├── api/
-│   │   └── google_books.py
-│   ├── utils/
-│   │   ├── validators.py
-│   │   └── file_manager.py
-│   ├── main.py
-│   └── report.py
-├── tests/
-│   ├── test_users.py
-│   ├── test_books.py
-│   └── test_loans.py
-└── README.md
+## ▶️ Run the Challenge
+
+```bash
+cd Week2OOP/Day5MiniProject/DailyChallenge
+python anagram_checker_all.py
 ```
 
----
-
-## ✅ Criterios de Éxito
-- [ ] Integración de todos los conceptos de la semana
-- [ ] Código modular, limpio y documentado
-- [ ] Validación y manejo de errores robusto
-- [ ] Testing funcional
-- [ ] Reportes útiles y bien presentados
+You should see output similar to the screenshot described in the main README_ANAGRAMS guide: the program echoes the uppercase version of your word, states if it is valid, and lists its anagrams.
 
 ---
 
-**💡 Consejo**: Prioriza la claridad, la validación y la documentación. Justifica tus decisiones de diseño y asegúrate de que el sistema sea fácil de mantener y extender.
+## 🛠️ Want to Extend It?
 
-**🎯 Meta**: Entregar un sistema profesional, funcional y bien documentado que demuestre dominio de OOP, manejo de datos y buenas prácticas de desarrollo.
+`README_ANAGRAMS.md` includes ideas for:
+
+- Splitting the all-in-one script into `anagram_checker.py` (logic) and `anagrams.py` (CLI).
+- Swapping in a larger dictionary for `words.txt`.
+- Adding unit tests or alternative interfaces.
+
+Treat those as stretch goals once you understand the baseline solution.
+
+---
+
+## ✅ Deliverable Checklist
+
+- [ ] Review `README_ANAGRAMS.md` to understand the project expectations.
+- [ ] Run `anagram_checker_all.py` and test several valid and invalid words.
+- [ ] Capture notes or screenshots if your instructor asks for proof of completion.
+
+Have fun discovering new anagrams! 🔤🐍

--- a/Week2OOP/Day5MiniProject/DailyChallenge/README_ANAGRAMS.md
+++ b/Week2OOP/Day5MiniProject/DailyChallenge/README_ANAGRAMS.md
@@ -1,5 +1,7 @@
 # Mini‑Project – Anagram Checker (All‑In‑One) ✨
 
+> Looking for the quick overview? The parent [`README.md`](../README.md) and the Daily Challenge [`README.md`](README.md) both summarise this guide and link back here. Everything below remains the canonical, in-depth reference.
+
 This mini‑project bundles both the **logic class** and a **simple CLI** into a single file for convenience. Code is simple, commented in English, and includes friendly emojis.
 
 ---
@@ -24,10 +26,10 @@ python anagram_checker_all.py
 ```
 
 You’ll see a simple menu:
-1) Input a word  
+1) Input a word
 2) Exit
 
-Type `1`, then enter a **single alphabetic word** (no spaces, no digits, no symbols).  
+Type `1`, then enter a **single alphabetic word** (no spaces, no digits, no symbols).
 The program will print:
 - `YOUR WORD : "WORDINUPPERCASE"`
 - Whether it is a valid English word (present in `words.txt`)
@@ -37,8 +39,8 @@ The program will print:
 
 ## 🧠 How It Works
 
-- The class loads `words.txt`, keeping a **set** for quick validity checks and a **signature index**:  
-  `signature = letters of the word sorted (e.g., "meat" -> "aemt")`  
+- The class loads `words.txt`, keeping a **set** for quick validity checks and a **signature index**:
+  `signature = letters of the word sorted (e.g., "meat" -> "aemt")`
   Words with the same signature are anagrams of each other.
 - `is_valid_word(word)` checks membership in the set.
 - `get_anagrams(word)` looks up by signature and **excludes the original word**.
@@ -48,7 +50,7 @@ The program will print:
 
 ## 📝 Customize
 
-- Edit `words.txt` to add/remove words. You can separate by whitespace or put one word per line.  
+- Edit `words.txt` to add/remove words. You can separate by whitespace or put one word per line.
 - You can replace the fallback list entirely with your own dictionary (for example, a larger English word list).
 
 ---

--- a/Week2OOP/Day5MiniProject/Exercises/README.md
+++ b/Week2OOP/Day5MiniProject/Exercises/README.md
@@ -1,70 +1,38 @@
-# 🛠️ Day 5 Exercises - Mini Project
+# 🛠️ Optional Day 5 Milestones – Anagram Checker
 
-## 🎯 Objetivo de los Ejercicios
+The original step-by-step exercises for a library system are now **deprecated**. Day 5 focuses solely on the Anagram Checker mini-project that lives in [`../DailyChallenge`](../DailyChallenge). If you would like structured milestones to rebuild the solution from scratch, follow the sequence below.
 
-Estos ejercicios te ayudarán a construir paso a paso el sistema integral de biblioteca digital, aplicando todos los conceptos de la semana.
-
----
-
-## 🥉 Exercise 1: Modelado de Clases
-
-### 📚 Descripción
-Diseña las clases principales del sistema: `User`, `Book`, `Loan`.
-
-### 📋 Requisitos
-- Definir atributos y métodos clave para cada clase
-- Implementar relaciones entre clases (ej: un usuario puede tener varios préstamos)
-- Añadir validaciones básicas en los constructores
-- Documentar cada clase con docstrings
+> 📚 Need the complete write-up? Read [`../DailyChallenge/README_ANAGRAMS.md`](../DailyChallenge/README_ANAGRAMS.md). It contains the official project description, file details, and extension ideas.
 
 ---
 
-## 🥈 Exercise 2: Carga y Validación de Datos
+## 🥉 Milestone 1 – Load the Dictionary
 
-### 📊 Descripción
-Implementa la carga de datos de libros desde un archivo CSV y/o una API externa.
+- Create a helper function that reads `words.txt` and returns both a set of valid words and a mapping of sorted-letter signatures to word lists.
+- Ensure the loader can create `words.txt` with a sensible default list when the file is missing (see README_ANAGRAMS for the fallback content).
+- Add light error handling so the script exits gracefully if the file cannot be created or read.
 
-### 📋 Requisitos
-- Leer datos de libros desde CSV usando pandas o csv
-- Validar y transformar los datos cargados
-- Integrar datos adicionales desde una API (ej: Google Books)
-- Manejar errores de formato y datos faltantes
+## 🥈 Milestone 2 – Implement `AnagramChecker`
 
----
+- Build the `AnagramChecker` class around the loader from Milestone 1.
+- Implement and test the trio of public methods used by the CLI:
+  - `is_valid_word(word)`
+  - `get_anagrams(word)`
+  - `is_anagram(word_one, word_two)`
+- Keep the methods free of `print` statements; return values instead so they can be reused.
 
-## 🥇 Exercise 3: Gestión de Préstamos y Persistencia
+## 🥇 Milestone 3 – Craft the CLI
 
-### 💾 Descripción
-Desarrolla la lógica para registrar préstamos y devoluciones, y almacena los datos en archivos JSON.
-
-### 📋 Requisitos
-- Métodos para registrar préstamo y devolución de libros
-- Validar disponibilidad de libros y usuarios
-- Guardar y cargar usuarios y préstamos en JSON
-- Manejar errores de concurrencia y duplicados
+- Wrap the class in a small menu-driven interface (exactly what `anagram_checker_all.py` provides).
+- Validate user input, format the output clearly, and display friendly emojis to match the all-in-one reference implementation.
+- When everything works, compare your solution with `anagram_checker_all.py` to spot improvements or refactors you might borrow.
 
 ---
 
-## 💪 Exercise 4: Reportes y Testing
+## ✅ When Are You Done?
 
-### 📈 Descripción
-Implementa generación de reportes y pruebas unitarias para el sistema.
+- [ ] Each milestone runs without errors and uses the same behaviours documented in `README_ANAGRAMS.md`.
+- [ ] Your final script can either be the provided `anagram_checker_all.py` or a refactored two-file version.
+- [ ] You have explored at least a couple of stretch ideas (larger dictionary, unit tests, different UI) if time permits.
 
-### 📋 Requisitos
-- Generar reportes de libros más prestados, usuarios activos, etc.
-- Crear pruebas unitarias para los módulos principales
-- Documentar el flujo de trabajo y decisiones de diseño
-
----
-
-## ✅ Criterios de Evaluación
-- [ ] Modelado OOP correcto y documentado
-- [ ] Carga y validación de datos robusta
-- [ ] Persistencia y gestión de préstamos funcional
-- [ ] Reportes útiles y pruebas unitarias
-
----
-
-**💡 Consejo**: Trabaja de forma incremental, validando cada parte antes de avanzar. Usa tests para asegurar la calidad del sistema.
-
-**🎯 Meta**: Construir un sistema profesional, modular y bien probado que integre todos los aprendizajes de la semana.
+Enjoy levelling up your string-manipulation skills! 🔡🚀

--- a/Week2OOP/Day5MiniProject/README.md
+++ b/Week2OOP/Day5MiniProject/README.md
@@ -1,93 +1,58 @@
-# 🚀 Day 5 - Mini Project: Integrating OOP and Data Concepts
+# 🔤 Day 5 Mini Project – Anagram Checker
 
-## 🎯 Goal of the Day
+Welcome to the final project of the Python OOP module! Instead of building a large library system, Day 5 now focuses on a compact but complete **Anagram Checker** that lets you practise object-oriented design, modular thinking, file handling, and simple CLI flows all in one place.
 
-Develop a **complete project** that integrates all the concepts learned during the week:
-- Advanced object-oriented programming
-- Modular organization and packages
-- File and external data handling (CSV, JSON, APIs)
-- Validation, testing, and documentation
+If you prefer a detailed, learner-friendly walkthrough, jump straight to [`DailyChallenge/README_ANAGRAMS.md`](DailyChallenge/README_ANAGRAMS.md). The highlights are summarised below so the whole folder stays in sync.
 
 ---
 
-## 🏆 Main Challenge: "Comprehensive Digital Library Management System"
+## 🧩 What You Will Build
 
-### 📚 General Description
-Create a digital library system that allows you to:
-- Manage users, books, loans, and returns
-- Integrate book data from CSV files and external APIs (e.g., Google Books)
-- Store and query information in JSON files
-- Generate usage reports and statistics
-- Validate data and handle errors robustly
+You will create an `AnagramChecker` class and a lightweight command-line interface that work together to:
+
+- Validate whether a user-provided word exists in the supplied dictionary.
+- Find all valid anagrams for that word (excluding the word itself).
+- Offer a tiny menu so learners can explore different inputs quickly.
+
+All of this lives in a single script, [`DailyChallenge/anagram_checker_all.py`](DailyChallenge/anagram_checker_all.py), which keeps the mini-project approachable while still demonstrating good design practices.
 
 ---
 
-## 🏗️ Suggested Architecture
+## 📂 Project Layout
 
 ```
 Day5MiniProject/
-├── data/
-│   ├── books.csv
-│   ├── users.json
-│   └── loans.json
-├── src/
-│   ├── models/
-│   │   ├── user.py
-│   │   ├── book.py
-│   │   └── loan.py
-│   ├── services/
-│   │   ├── user_service.py
-│   │   ├── book_service.py
-│   │   └── loan_service.py
-│   ├── api/
-│   │   └── google_books.py
-│   ├── utils/
-│   │   ├── validators.py
-│   │   └── file_manager.py
-│   ├── main.py
-│   └── report.py
-├── tests/
-│   ├── test_users.py
-│   ├── test_books.py
-│   └── test_loans.py
-└── README.md
+├── DailyChallenge/
+│   ├── README_ANAGRAMS.md   # Canonical, in-depth guide
+│   ├── README.md            # Mirrors this overview for daily challenge context
+│   └── anagram_checker_all.py
+├── Exercises/
+│   └── README.md            # Optional milestones if you want to rebuild the tool in stages
+└── README.md                # (you are here)
 ```
 
----
-
-## 📋 Technical Requirements
-
-- Implement OOP classes for users, books, and loans
-- Read and load book data from CSV and/or external API
-- Store users and loans in JSON
-- Validate input data and handle errors
-- Generate reports for most borrowed books, active users, etc.
-- Unit testing for main modules
-- Document the system and its modules
+Feel free to split the code into multiple modules (`anagram_checker.py`, `anagrams.py`) if you want a multi-file structure. The README_ANAGRAMS file explains how to do that refactor safely.
 
 ---
 
-## 📝 Suggested Workflow
+## ▶️ Quick Start
 
-1. **Class and Module Design**: Define the main classes and their relationships.
-2. **Data Loading**: Implement book import from CSV and API.
-3. **User and Loan Management**: Methods for adding, removing, loaning, and returning.
-4. **Persistence**: Save and load data in JSON.
-5. **Reports**: Generate useful reports and statistics.
-6. **Testing**: Create unit tests for key modules.
-7. **Documentation**: Explain the design, usage, and decisions.
+```bash
+cd Week2OOP/Day5MiniProject/DailyChallenge
+python anagram_checker_all.py
+```
 
----
-
-## ✅ Evaluation Criteria
-- [ ] Integration of all weekly concepts
-- [ ] Modular, clean, and well-documented code
-- [ ] Robust validation and error handling
-- [ ] Functional testing
-- [ ] Useful and well-presented reports
+You will see a two-option menu: enter a word or exit. Provide a single alphabetical word and the CLI will print whether it is valid and list any anagrams.
 
 ---
 
-**💡 Tip**: Prioritize clarity and maintainability. Document each module and justify your design decisions.
+## 📘 Need More Detail?
 
-**🎯 Goal**: Deliver a functional, professional, and well-documented system that demonstrates mastery of OOP, data handling, and development best practices.
+Head over to [`DailyChallenge/README_ANAGRAMS.md`](DailyChallenge/README_ANAGRAMS.md) for:
+
+- A full description of the helper methods and CLI flow
+- Notes about the bundled `words.txt` (including its auto-generation behaviour)
+- Tips for extending or refactoring the project
+- Git workflow reminders when you are ready to publish your work
+
+Happy word play! 🐍✨


### PR DESCRIPTION
## Summary
- replace the Day 5 mini-project README with an overview of the anagram checker and its primary script
- rewrite the Daily Challenge and Exercises READMEs to reflect the current anagram mini-project and reference the canonical guide
- cross-link README_ANAGRAMS back to the overview so learners receive consistent instructions

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68df5ddec4d4832b8943973841fdc6ad