### PR TITLE
Fix Exercises XP README heading and script references

### DIFF
--- a/Week1Python/Day2ListsIteratingAndFormattingData/Exercises/ExercisesXP/README.md
+++ b/Week1Python/Day2ListsIteratingAndFormattingData/Exercises/ExercisesXP/README.md
@@ -1,4 +1,4 @@
-# 🏋️ ## 📋 What's inside (quick tour)xercises XP — Sequence / List / Set / Tuple 
+# 🏋️ Exercises XP — Sequence / List / Set / Tuple
 
 A small, single-file collection that practices **sets, tuples, lists, loops, and user input**.
 
@@ -52,17 +52,17 @@ A small, single-file collection that practices **sets, tuples, lists, loops, and
 
 ## ▶️ How to run
 ### Option A — Double-click (if `.py` is associated with Python)
-- Save as `exercises_xp_sequences.py` and double-click.
+- Save as `exercisesxp.py` and double-click.
 
 ### Option B — Terminal / Command Prompt
 ```bash
 # macOS / Linux
-python3 exercises_xp_sequences.py
+python3 exercisesxp.py
 
 # Windows
-python exercises_xp_sequences.py
+python exercisesxp.py
 # or
-py exercises_xp_sequences.py
+py exercisesxp.py
 ```
 You’ll be prompted for input in several parts (Exercises **6–9**).
 


### PR DESCRIPTION
## Summary
- update the Exercises XP README title to a clean heading
- replace run instructions to point to exercisesxp.py consistently

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e14e7146d4832bac5a9aa203e75c4b