### PR TITLE
Refactor build up string script into main entry point

### DIFF
--- a/Week1Python/Day1StartingwithPython/DailyChallenge/BuildUpAString/buildupastring.py
+++ b/Week1Python/Day1StartingwithPython/DailyChallenge/BuildUpAString/buildupastring.py
@@ -1,28 +1,52 @@
-# Daily challenge: Build up a string
+"""Daily challenge: Build up a string."""
 
-s = input("Enter a string (must be exactly 10 characters): ")
+from __future__ import annotations
 
-# 1-2) Length checks
-if len(s) < 10:
-    print("String not long enough.")
-elif len(s) > 10:
-    print("String too long.")
-else:
-    print("Perfect string")
+import random
 
-    # 3) First and last characters
-    print("First character:", s[0])
-    print("Last character:", s[-1])
 
-    # 4) Build the string character by character
+def validate_length(text: str) -> tuple[bool, str]:
+    """Return whether the text is exactly 10 characters with a feedback message."""
+    if len(text) < 10:
+        return False, "String not long enough."
+    if len(text) > 10:
+        return False, "String too long."
+    return True, "Perfect string"
+
+
+def build_up_text(text: str) -> None:
+    """Print the incremental build-up of the provided text."""
     built = ""
-    for ch in s:
+    for ch in text:
         built += ch
         print(built)
 
-    # 5) Bonus: jumble (shuffle) the string
-    import random
-    chars = list(s)
+
+def jumble_text(text: str) -> str:
+    """Return a shuffled version of the provided text."""
+    chars = list(text)
     random.shuffle(chars)
-    jumbled = "".join(chars)
-    print("Jumbled string:", jumbled)
+    return "".join(chars)
+
+
+def main() -> None:
+    """Run the interactive build-up challenge."""
+    user_input = input("Enter a string (must be exactly 10 characters): ")
+    is_valid, message = validate_length(user_input)
+    print(message)
+    if not is_valid:
+        return
+
+    # 🧩 Show the first and last characters for quick insights.
+    print("First character:", user_input[0])
+    print("Last character:", user_input[-1])
+
+    # 🚧 Build the string character by character for visualization.
+    build_up_text(user_input)
+
+    # 🔀 Display a jumbled version for fun.
+    print("Jumbled string:", jumble_text(user_input))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refactor the build-up-a-string script into a `main()` entry point with helpers for validation, progressive display, and jumbling
- add an `if __name__ == "__main__"` guard so the script only runs when executed directly

## Testing
- python -m compileall Week1Python/Day1StartingwithPython/DailyChallenge/BuildUpAString/buildupastring.py

------
https://chatgpt.com/codex/tasks/task_e_68e16838a278832b9a3d55fff8d020c6