### PR TITLE
chore: add eslint and prettier tooling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+node_modules/
+**/dist/
+**/build/
+**/.turbo/
+Week5MiniProjectAndTypeScript/**/compiled/
+Week5MiniProjectAndTypeScript/**/out/
+Week5MiniProjectAndTypeScript/**/data/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,51 @@
+// Module: eslint-config
+// Purpose: Centralize linting defaults for browser exercises and TypeScript tooling across the curriculum.
+// Author: Kevin "Lirioth" Cusnir
+// Date: 2025-10-09 | TZ: Asia/Jerusalem
+// Notes: Comments in ENGLISH; emojis sparingly.
+
+module.exports = {
+  root: true,
+  env: {
+    browser: false,
+    node: true,
+    es2021: true
+  },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  overrides: [
+    {
+      files: ['**/*.ts'],
+      parserOptions: {
+        ecmaVersion: 12,
+        sourceType: 'module'
+      },
+      plugins: ['@typescript-eslint']
+    },
+    {
+      files: ['Week3JavaScriptandDOM/**/*.js'],
+      env: {
+        browser: true,
+        node: false,
+        es2021: true
+      },
+      globals: {
+        window: 'readonly',
+        document: 'readonly'
+      }
+    }
+  ],
+  ignorePatterns: [
+    'node_modules/',
+    '**/dist/',
+    '**/build/',
+    '**/.turbo/',
+    'Week5MiniProjectAndTypeScript/**/compiled/',
+    'Week5MiniProjectAndTypeScript/**/out/'
+  ]
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules/
+**/dist/
+**/build/
+**/.turbo/
+Week5MiniProjectAndTypeScript/**/compiled/
+Week5MiniProjectAndTypeScript/**/out/
+Week5MiniProjectAndTypeScript/**/data/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Each week follows a consistent structure:
 3. **Editor setup**
    - Enable ESLint/Prettier or equivalent formatters to keep JS/TS code consistent.
    - Install Python and TypeScript language extensions for intellisense and type checking.
+4. **Project tooling**
+   - Run `npm install` in the repository root once to download the shared ESLint/Prettier toolchain ⚙️.
+   - Run `npm run lint` to audit Week3 JavaScript and Week5 TypeScript sources for common pitfalls before submitting work.
+   - Run `npm run format` to apply Prettier's consistent spacing and punctuation rules across those folders.
 
 ---
 ## 6. ▶️ Running & Testing Code
@@ -197,6 +201,11 @@ Each week follows a consistent structure:
 | 🔷 Week5 | Execute TypeScript via `npx ts-node` or compile with `npx tsc` followed by `node` for grader-friendly outputs.【F:Week5MiniProjectAndTypeScript/Day2IntroductionToTypeScriptAndKeyConcepts/DailyChallenge/README.md†L15-L23】 |
 
 > 💡 **Automation idea**: Add npm scripts (`npm run dev:week4`) to standardise local servers and TS execution.
+
+### 🧰 Shared npm scripts
+
+- `npm run lint`: Executes ESLint against `Week3JavaScriptandDOM/**/*.js` and `Week5MiniProjectAndTypeScript/**/*.ts`, blending browser and Node environments for accurate feedback.
+- `npm run format`: Runs Prettier in write mode across the same paths to keep diffs minimal and beginner-friendly.
 
 ---
 ## 7. 📁 Project Structure & Standards

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fullstack2026",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "eslint \"Week3JavaScriptandDOM/**/*.js\" \"Week5MiniProjectAndTypeScript/**/*.ts\"",
+    "format": "prettier --write \"Week3JavaScriptandDOM/**/*.js\" \"Week5MiniProjectAndTypeScript/**/*.ts\""
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.3.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root package.json with eslint/prettier devDependencies and helper scripts
- configure eslint to cover TypeScript tooling and browser-only Week 3 scripts, plus matching prettier settings and ignores
- document the npm install, lint, and format workflow in the main README

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68e7f8cdad1c832baf81cea860f1ce1d